### PR TITLE
add mason

### DIFF
--- a/bytestring-builders-benchmark.cabal
+++ b/bytestring-builders-benchmark.cabal
@@ -52,7 +52,8 @@ library
     bytestring-strict-builder >= 0.4.3 && < 0.5,
     binary >= 0.8 && < 0.10,
     cereal == 0.5.*,
-    fast-builder == 0.0.0.6,
+    fast-builder ^>=0.1,
+    mason ^>=0.2,
     -- general:
     rerebase == 1.*
 

--- a/library/ByteString/BuildersBenchmark/Benchmarks.hs
+++ b/library/ByteString/BuildersBenchmark/Benchmarks.hs
@@ -19,6 +19,7 @@ allSubjects groupName subjectBench =
       subjectBench "blazeBuilder" A.blazeBuilder :
       subjectBench "binary" A.binary :
       subjectBench "cereal" A.cereal :
+      subjectBench "mason" A.masonBuilder :
       []
 {-# INLINE allSubjects #-}
 

--- a/library/ByteString/BuildersBenchmark/Subjects.hs
+++ b/library/ByteString/BuildersBenchmark/Subjects.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString.Lazy as D
 import qualified Data.ByteString.Builder as F
 import qualified Data.ByteString.FastBuilder as H
 import qualified Blaze.ByteString.Builder as I
+import qualified Mason.Builder as M
 
 
 data Subject =
@@ -55,3 +56,8 @@ blazeBuilder :: Subject
 blazeBuilder =
   Subject mempty mappend mconcat foldMap I.fromByteString (D.toStrict . I.toLazyByteString)
 {-# INLINE blazeBuilder #-}
+
+masonBuilder :: Subject
+masonBuilder =
+  Subject mempty mappend mconcat foldMap M.byteString M.toStrictByteString
+{-# INLINE masonBuilder #-}


### PR DESCRIPTION
Added mason to the benchmark subjects.

```
averagedAppends-1/byteStringStrictBuilder mean 116.3 ns  ( +- 6.479 ns  )
averagedAppends-1/byteStringTreeBuilder  mean 181.7 ns  ( +- 20.88 ns  )
averagedAppends-1/fastBuilder            mean 181.5 ns  ( +- 7.219 ns  )
averagedAppends-1/bufferBuilder          mean 728.5 ns  ( +- 9.114 ns  )
averagedAppends-1/byteString             mean 358.7 ns  ( +- 4.663 ns  )
averagedAppends-1/blazeBuilder           mean 356.0 ns  ( +- 7.604 ns  )
averagedAppends-1/binary                 mean 635.0 ns  ( +- 7.936 ns  )
averagedAppends-1/cereal                 mean 638.6 ns  ( +- 12.40 ns  )
averagedAppends-1/mason                  mean 155.2 ns  ( +- 2.000 ns  )
averagedAppends-100/byteStringStrictBuilder mean 7.290 μs  ( +- 99.74 ns  )
averagedAppends-100/byteStringTreeBuilder mean 13.40 μs  ( +- 283.4 ns  )
averagedAppends-100/fastBuilder          mean 13.07 μs  ( +- 418.2 ns  )
averagedAppends-100/bufferBuilder        mean 19.57 μs  ( +- 5.644 μs  )
averagedAppends-100/byteString           mean 17.31 μs  ( +- 1.609 μs  )
averagedAppends-100/blazeBuilder         mean 19.15 μs  ( +- 6.533 μs  )
averagedAppends-100/binary               mean 48.26 μs  ( +- 727.1 ns  )
averagedAppends-100/cereal               mean 51.57 μs  ( +- 21.81 μs  )
averagedAppends-100/mason                mean 12.07 μs  ( +- 233.8 ns  )
averagedAppends-10000/byteStringStrictBuilder mean 1.038 ms  ( +- 18.63 μs  )
averagedAppends-10000/byteStringTreeBuilder mean 1.989 ms  ( +- 70.63 μs  )
averagedAppends-10000/fastBuilder        mean 1.611 ms  ( +- 42.24 μs  )
averagedAppends-10000/bufferBuilder      mean 1.895 ms  ( +- 25.09 μs  )
averagedAppends-10000/byteString         mean 2.248 ms  ( +- 40.99 μs  )
averagedAppends-10000/blazeBuilder       mean 2.394 ms  ( +- 1.016 ms  )
averagedAppends-10000/binary             mean 6.503 ms  ( +- 157.6 μs  )
averagedAppends-10000/cereal             mean 6.458 ms  ( +- 221.6 μs  )
averagedAppends-10000/mason              mean 1.738 ms  ( +- 25.89 μs  )
regularConcat-100/byteStringStrictBuilder mean 1.606 μs  ( +- 32.93 ns  )
regularConcat-100/byteStringTreeBuilder  mean 2.000 μs  ( +- 43.73 ns  )
regularConcat-100/fastBuilder            mean 1.364 μs  ( +- 37.95 ns  )
regularConcat-100/bufferBuilder          mean 2.204 μs  ( +- 48.40 ns  )
regularConcat-100/byteString             mean 1.253 μs  ( +- 25.68 ns  )
regularConcat-100/blazeBuilder           mean 1.317 μs  ( +- 24.05 ns  )
regularConcat-100/binary                 mean 2.845 μs  ( +- 62.24 ns  )
regularConcat-100/cereal                 mean 3.021 μs  ( +- 48.53 ns  )
regularConcat-100/mason                  mean 1.405 μs  ( +- 35.11 ns  )
regularConcat-10000/byteStringStrictBuilder mean 321.3 μs  ( +- 11.13 μs  )
regularConcat-10000/byteStringTreeBuilder mean 349.1 μs  ( +- 4.359 μs  )
regularConcat-10000/fastBuilder          mean 121.0 μs  ( +- 1.755 μs  )
regularConcat-10000/bufferBuilder        mean 156.1 μs  ( +- 2.050 μs  )
regularConcat-10000/byteString           mean 106.6 μs  ( +- 1.355 μs  )
regularConcat-10000/blazeBuilder         mean 110.8 μs  ( +- 1.397 μs  )
regularConcat-10000/binary               mean 308.1 μs  ( +- 5.346 μs  )
regularConcat-10000/cereal               mean 352.0 μs  ( +- 6.142 μs  )
regularConcat-10000/mason                mean 130.2 μs  ( +- 10.39 μs  )
```